### PR TITLE
Refactor logging to use ESP_LOG instead of printf

### DIFF
--- a/core/GameRegistry.cpp
+++ b/core/GameRegistry.cpp
@@ -4,6 +4,10 @@
 
 static const char *TAG = "GameRegistry";
 
+GameRegistry::GameRegistry() {
+    ESP_LOGI(TAG, "GameRegistry constructor called");
+}
+
 GameRegistry& GameRegistry::instance() {
     static GameRegistry inst;
     return inst;

--- a/core/GameRegistry.cpp
+++ b/core/GameRegistry.cpp
@@ -2,7 +2,7 @@
 #include <cstdio>
 #include "esp_log.h"
 
-static const char *TAG = "MyComponent";
+static const char *TAG = "GameRegistry";
 
 GameRegistry& GameRegistry::instance() {
     static GameRegistry inst;

--- a/core/GameRegistry.cpp
+++ b/core/GameRegistry.cpp
@@ -1,5 +1,8 @@
 #include "GameRegistry.hpp"
 #include <cstdio>
+#include "esp_log.h"
+
+static const char *TAG = "MyComponent";
 
 GameRegistry& GameRegistry::instance() {
     static GameRegistry inst;
@@ -7,21 +10,21 @@ GameRegistry& GameRegistry::instance() {
 }
 
 void GameRegistry::registerGame(const std::string& name, CreateGameFn fn) {
-    printf("GameRegistry::registerGame called for game: %s\n", name.c_str());
+    ESP_LOGI(TAG, "GameRegistry::registerGame called for game: %s", name.c_str());
     games_.push_back({name, std::move(fn)});
-    printf("Games count after registration: %zu\n", games_.size());
+    ESP_LOGI(TAG, "Games count after registration: %zu", games_.size());
 }
 
 const std::vector<GameFactory>& GameRegistry::available() const {
-    printf("GameRegistry::available() called, games count: %zu\n", games_.size());
+    ESP_LOGI(TAG, "GameRegistry::available() called, games count: %zu", games_.size());
     return games_;
 }
 
 void GameRegistry::debugPrintGames() const {
-    printf("===== REGISTERED GAMES =====\n");
-    printf("Number of registered games: %zu\n", games_.size());
+    ESP_LOGI(TAG, "===== REGISTERED GAMES =====");
+    ESP_LOGI(TAG, "Number of registered games: %zu", games_.size());
     for (size_t i = 0; i < games_.size(); i++) {
-        printf("Game %zu: %s\n", i, games_[i].name.c_str());
+        ESP_LOGI(TAG, "Game %zu: %s", i, games_[i].name.c_str());
     }
-    printf("============================\n");
+    ESP_LOGI(TAG, "============================");
 }

--- a/core/GameRegistry.hpp
+++ b/core/GameRegistry.hpp
@@ -4,9 +4,6 @@
 #include <vector>
 #include <string>
 #include <memory>
-#include "esp_log.h"
-
-static const char *TAG = "GameRegistry";
 
 using CreateGameFn = std::function<std::unique_ptr<Game>()>;
 
@@ -23,8 +20,6 @@ public:
     const std::vector<GameFactory>& available() const;
     void debugPrintGames() const;
 private:
-    GameRegistry() {
-        ESP_LOGI(TAG, "GameRegistry constructor called");
-    }
+    GameRegistry();
     std::vector<GameFactory> games_;
 };

--- a/core/GameRegistry.hpp
+++ b/core/GameRegistry.hpp
@@ -6,7 +6,7 @@
 #include <memory>
 #include "esp_log.h"
 
-static const char *TAG = "MyComponent";
+static const char *TAG = "GameRegistry";
 
 using CreateGameFn = std::function<std::unique_ptr<Game>()>;
 

--- a/core/GameRegistry.hpp
+++ b/core/GameRegistry.hpp
@@ -4,6 +4,9 @@
 #include <vector>
 #include <string>
 #include <memory>
+#include "esp_log.h"
+
+static const char *TAG = "MyComponent";
 
 using CreateGameFn = std::function<std::unique_ptr<Game>()>;
 
@@ -21,7 +24,7 @@ public:
     void debugPrintGames() const;
 private:
     GameRegistry() {
-        printf("GameRegistry constructor called\n");
+        ESP_LOGI(TAG, "GameRegistry constructor called");
     }
     std::vector<GameFactory> games_;
 };

--- a/games/arkanoid/Arkanoid.cpp
+++ b/games/arkanoid/Arkanoid.cpp
@@ -4,9 +4,12 @@
 #include "lvgl_helper.hpp"
 #include <cstdio>
 #include <cmath>
+#include "esp_log.h"
+
+static const char *TAG = "MyComponent";
 
 RegisterArkanoid::RegisterArkanoid() {
-    printf("Registering Arkanoid game\n");
+    ESP_LOGI(TAG, "Registering Arkanoid game");
     GameRegistry::instance().registerGame("Arkanoid", []() {
         return std::make_unique<Arkanoid>();
     });
@@ -33,7 +36,7 @@ Arkanoid::~Arkanoid() {
 }
 
 void Arkanoid::run() {
-    printf("Starting Arkanoid game\n");
+    ESP_LOGI(TAG, "Starting Arkanoid game");
     createGameScreen();
     resetGame();
     gameRunning_ = true;
@@ -84,7 +87,7 @@ void Arkanoid::stop() {
     if (stopped_) return;
     stopped_ = true;
 
-    printf("Arkanoid::stop() called\n");
+    ESP_LOGI(TAG, "Arkanoid::stop() called");
     gameRunning_ = false;
     
     if (updateTimer_) {
@@ -130,7 +133,7 @@ void Arkanoid::handleKey(uint32_t key) {
                 ball_.vx = ballSpeed_;
                 ball_.vy = -ballSpeed_;
                 enterPressed_ = true;
-                printf("Ball launched!\n");
+                ESP_LOGI(TAG, "Ball launched!");
             }
             break;
             

--- a/games/arkanoid/Arkanoid.cpp
+++ b/games/arkanoid/Arkanoid.cpp
@@ -6,7 +6,7 @@
 #include <cmath>
 #include "esp_log.h"
 
-static const char *TAG = "MyComponent";
+static const char *TAG = "Arkanoid";
 
 RegisterArkanoid::RegisterArkanoid() {
     ESP_LOGI(TAG, "Registering Arkanoid game");

--- a/games/game2048/Game2048.cpp
+++ b/games/game2048/Game2048.cpp
@@ -4,7 +4,7 @@
 #include <cstdio>
 #include "esp_log.h"
 
-static const char *TAG = "MyComponent";
+static const char *TAG = "Game2048";
 #include <cstring>
 
 Game2048::~Game2048() {

--- a/games/game2048/Game2048.cpp
+++ b/games/game2048/Game2048.cpp
@@ -2,6 +2,9 @@
 #include "GameRegistry.hpp"
 #include "lvgl_helper.hpp"
 #include <cstdio>
+#include "esp_log.h"
+
+static const char *TAG = "MyComponent";
 #include <cstring>
 
 Game2048::~Game2048() {
@@ -47,7 +50,7 @@ void Game2048::stop() {
     if(stopped_) return;
     stopped_ = true;
     gameRunning_ = false;
-    printf("2048::stop() called\n");
+    ESP_LOGI(TAG, "2048::stop() called");
 
     if(screen_ && lv_obj_is_valid(screen_)) {
         lv_obj_clean(screen_);
@@ -56,7 +59,7 @@ void Game2048::stop() {
         screen_ = nullptr;
     }
 
-    printf("2048::stop() completed\n");
+    ESP_LOGI(TAG, "2048::stop() completed");
 }
 
 void Game2048::handleKey(uint32_t key) {

--- a/games/racing/Racing.cpp
+++ b/games/racing/Racing.cpp
@@ -5,6 +5,9 @@
 
 #include <cstdio>
 #include <algorithm>
+#include "esp_log.h"
+
+static const char *TAG = "MyComponent";
 
 
 RegisterRacing::RegisterRacing() {
@@ -62,7 +65,7 @@ void Racing::stop() {
     if (stopped_) return;
     stopped_ = true;
 
-    printf("Racing::stop() called\n");
+    ESP_LOGI(TAG, "Racing::stop() called");
     gameRunning_ = false;
 
     if (updateTimer_) {
@@ -101,7 +104,7 @@ void Racing::stop() {
         screen_ = nullptr;
     }
     
-    printf("Racing::stop() completed\n");
+    ESP_LOGI(TAG, "Racing::stop() completed");
 }
 
 void Racing::cleanupPlayer() {

--- a/games/racing/Racing.cpp
+++ b/games/racing/Racing.cpp
@@ -7,7 +7,7 @@
 #include <algorithm>
 #include "esp_log.h"
 
-static const char *TAG = "MyComponent";
+static const char *TAG = "Racing";
 
 
 RegisterRacing::RegisterRacing() {

--- a/games/simple_catcher/SimpleCatcher.cpp
+++ b/games/simple_catcher/SimpleCatcher.cpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include "esp_log.h"
 
-static const char *TAG = "MyComponent";
+static const char *TAG = "SimpleCatcher";
 
 RegisterSimpleCatcher::RegisterSimpleCatcher() {
     ESP_LOGI(TAG, "Registering Simple Catcher game");

--- a/games/simple_catcher/SimpleCatcher.cpp
+++ b/games/simple_catcher/SimpleCatcher.cpp
@@ -2,9 +2,12 @@
 #include "GameRegistry.hpp"
 #include <cstdio>
 #include <algorithm>
+#include "esp_log.h"
+
+static const char *TAG = "MyComponent";
 
 RegisterSimpleCatcher::RegisterSimpleCatcher() {
-    printf("Registering Simple Catcher game\n");
+    ESP_LOGI(TAG, "Registering Simple Catcher game");
     GameRegistry::instance().registerGame("Simple Catcher", []() {
         return std::make_unique<SimpleCatcher>();
     });
@@ -23,7 +26,7 @@ SimpleCatcher::~SimpleCatcher() {
 }
 
 void SimpleCatcher::run() {
-    printf("Starting Simple Catcher game\n");
+    ESP_LOGI(TAG, "Starting Simple Catcher game");
     createGameScreen();
     resetGame();
     gameRunning_ = true;

--- a/games/tower_bloxx/TowerBloxx.cpp
+++ b/games/tower_bloxx/TowerBloxx.cpp
@@ -8,6 +8,9 @@
 #include "green_centre.h"
 #include <cstdio>
 #include <algorithm>
+#include "esp_log.h"
+
+static const char *TAG = "MyComponent";
 
 RegisterTowerBloxx::RegisterTowerBloxx() {
     GameRegistry::instance().registerGame("Tower Bloxx", []() {
@@ -33,7 +36,7 @@ TowerBloxx::TowerBloxx()
      rd_(),
      gen_(rd_())
 {
-    printf("TowerBloxx constructor called\n");
+    ESP_LOGI(TAG, "TowerBloxx constructor called");
     currentBlock_.obj = nullptr;
     currentBlock_.x = 0;
     currentBlock_.y = 0;
@@ -43,17 +46,17 @@ TowerBloxx::TowerBloxx()
 }
 
 TowerBloxx::~TowerBloxx() {
-    printf("TowerBloxx destructor called\n");
+    ESP_LOGI(TAG, "TowerBloxx destructor called");
     stop();
 }
 
 void TowerBloxx::run() {
-    printf("TowerBloxx::run() called\n");
+    ESP_LOGI(TAG, "TowerBloxx::run() called");
     createGameScreen();
     gameRunning_ = true;      
     resetGame();
     waitingForPlayer_ = true;
-    printf("TowerBloxx game started, waiting for player input\n");
+    ESP_LOGI(TAG, "TowerBloxx game started, waiting for player input");
 }
 
 void TowerBloxx::update() {
@@ -61,16 +64,16 @@ void TowerBloxx::update() {
 }
 
 void TowerBloxx::stop() {
-    printf("TowerBloxx::stop() called\n");
+    ESP_LOGI(TAG, "TowerBloxx::stop() called");
     
     if (!gameRunning_ && !screen_) {
-        printf("TowerBloxx already stopped\n");
+        ESP_LOGW(TAG, "TowerBloxx already stopped");
         return;
     }
     
     gameRunning_ = false;
     
-    printf("Stopping all animations\n");
+    ESP_LOGI(TAG, "Stopping all animations");
     lv_anim_del_all();
     
     for (auto& block : blocks_) {
@@ -87,7 +90,7 @@ void TowerBloxx::stop() {
     }
     
     if (screen_) {
-        printf("Deleting screen\n");
+        ESP_LOGI(TAG, "Deleting screen");
         lv_obj_del(screen_);
         screen_ = nullptr;
         gameContainer_ = nullptr;
@@ -96,33 +99,33 @@ void TowerBloxx::stop() {
         instructionsLabel_ = nullptr;
     }
     
-    printf("TowerBloxx::stop() completed\n");
+    ESP_LOGI(TAG, "TowerBloxx::stop() completed");
 }
 
 void TowerBloxx::handleKey(uint32_t key) {
-    printf("TowerBloxx::handleKey called with key: %lu\n", key);
-    printf("Current state: gameRunning=%d, waitingForPlayer=%d, blockDropping=%d\n", 
+    ESP_LOGI(TAG, "TowerBloxx::handleKey called with key: %lu", key);
+    ESP_LOGI(TAG, "Current state: gameRunning=%d, waitingForPlayer=%d, blockDropping=%d",
            gameRunning_, waitingForPlayer_, blockDropping_);
-    printf("Current block: obj=%p, isMoving=%d\n", currentBlock_.obj, currentBlock_.isMoving);
+    ESP_LOGI(TAG, "Current block: obj=%p, isMoving=%d", currentBlock_.obj, currentBlock_.isMoving);
     
     if (!gameRunning_) return;
     
     switch (key) {
         case LV_KEY_ENTER:
         case LV_KEY_DOWN:
-            printf("Drop key pressed\n");
+            ESP_LOGI(TAG, "Drop key pressed");
             
             if (waitingForPlayer_) {
-                printf("Creating first block\n");
+                ESP_LOGI(TAG, "Creating first block");
                 spawnNewBlock();
                 waitingForPlayer_ = false;
             } 
             else if (currentBlock_.obj && currentBlock_.isMoving && !blockDropping_) {
-                printf("Dropping swinging block\n");
+                ESP_LOGI(TAG, "Dropping swinging block");
                 dropBlock();
             }
             else {
-                printf("No swinging block to drop or already dropping - ignoring input\n");
+                ESP_LOGI(TAG, "No swinging block to drop or already dropping - ignoring input");
             }
             break;
     }
@@ -161,7 +164,7 @@ void drawPlatformDecor(lv_obj_t* base) {
 }
 
 void TowerBloxx::createGameScreen() {
-    printf("TowerBloxx::createGameScreen() called\n");
+    ESP_LOGI(TAG, "TowerBloxx::createGameScreen() called");
     
     screen_ = createCleanObject(nullptr);
     lv_obj_set_style_bg_color(screen_, lv_color_make(235, 206, 135), 0);
@@ -183,7 +186,7 @@ void TowerBloxx::createGameScreen() {
         lv_obj_set_style_bg_opa(scoreLabel_, 180, 0);
         lv_obj_set_style_pad_all(scoreLabel_, 5, 0);
         lv_label_set_text(scoreLabel_, "Score: 0\nHeight: 0");
-        printf("scoreLabel created successfully\n");
+        ESP_LOGI(TAG, "scoreLabel created successfully");
     }
     
     towerBase_ = createCleanObject(gameContainer_);
@@ -202,14 +205,14 @@ void TowerBloxx::createGameScreen() {
     lv_obj_set_style_text_align(instructionsLabel_, LV_TEXT_ALIGN_CENTER, 0);
     
     lv_scr_load(screen_);
-    printf("Game screen created\n");
+    ESP_LOGI(TAG, "Game screen created");
 }
 
 void TowerBloxx::resetGame() {
-    printf("TowerBloxx::resetGame() called\n");
+    ESP_LOGI(TAG, "TowerBloxx::resetGame() called");
     
     if (!gameContainer_) {
-        printf("resetGame called but container null\n");
+        ESP_LOGW(TAG, "resetGame called but container null");
         return;
     }
     
@@ -222,24 +225,24 @@ void TowerBloxx::resetGame() {
 
     updateScore();
     
-    printf("Clearing existing blocks...\n");
+    ESP_LOGI(TAG, "Clearing existing blocks...");
     for (size_t i = 0; i < blocks_.size(); i++) {
         if (blocks_[i].obj) {
-            printf("Deleting block %zu obj=%p\n", i, blocks_[i].obj);
+            ESP_LOGI(TAG, "Deleting block %zu obj=%p", i, blocks_[i].obj);
             lv_obj_del(blocks_[i].obj);
         }
     }
     blocks_.clear();
-    printf("All blocks cleared. blocks_.size() = %zu\n", blocks_.size());
+    ESP_LOGI(TAG, "All blocks cleared. blocks_.size() = %zu", blocks_.size());
     
     if (currentBlock_.obj) {
-        printf("Clearing currentBlock_.obj=%p\n", currentBlock_.obj);
+        ESP_LOGI(TAG, "Clearing currentBlock_.obj=%p", currentBlock_.obj);
         lv_anim_del(currentBlock_.obj, NULL);
         lv_obj_del(currentBlock_.obj);
         currentBlock_.obj = nullptr;
     }
     
-    printf("Creating base block...\n");
+    ESP_LOGI(TAG, "Creating base block...");
     Block base;
     base.x = (lv_disp_get_hor_res(nullptr) - baseBlockWidth_) / 2;
     base.y = baseY_ - blockHeight_;
@@ -254,17 +257,17 @@ void TowerBloxx::resetGame() {
 
     blocks_.clear();
 
-    printf("Base block object created: %p\n", base.obj);
+    ESP_LOGI(TAG, "Base block object created: %p", base.obj);
 
     lv_obj_set_pos(base.obj, base.x, base.y);
 
-    printf("Adding base block to blocks_ vector...\n");
+    ESP_LOGI(TAG, "Adding base block to blocks_ vector...");
     blocks_.push_back(base);
-    printf("Base block added! blocks_.size() = %zu\n", blocks_.size());
-    printf("Base block details: obj=%p, pos=(%d,%d), size=%d\n", 
+    ESP_LOGI(TAG, "Base block added! blocks_.size() = %zu", blocks_.size());
+    ESP_LOGI(TAG, "Base block details: obj=%p, pos=(%d,%d), size=%d",
            blocks_[0].obj, blocks_[0].x, blocks_[0].y, blocks_[0].width);
     
-    printf("Reset game completed successfully\n");
+    ESP_LOGI(TAG, "Reset game completed successfully");
 }
 
 void TowerBloxx::spawnNewBlock() {
@@ -372,7 +375,7 @@ void TowerBloxx::updateCamera() {
 
     if (worldTopY < cameraY_ + desiredTopOffset) {
         cameraY_ = worldTopY - desiredTopOffset;
-        printf("CameraY updated: %d\n", cameraY_);
+        ESP_LOGI(TAG, "CameraY updated: %d", cameraY_);
 
         for (auto& block : blocks_) {
             if (block.obj) {
@@ -408,7 +411,7 @@ void TowerBloxx::updateCamera() {
 
 void TowerBloxx::updateScore() {
     if (!scoreLabel_) {
-        printf("updateScore called but scoreLabel is null\n");
+        ESP_LOGW(TAG, "updateScore called but scoreLabel is null");
         return;
     }
     
@@ -416,13 +419,13 @@ void TowerBloxx::updateScore() {
     int result = snprintf(scoreText, sizeof(scoreText), "Score: %d\nHeight: %d", score_, towerHeight_);
     
     if (result < 0 || result >= sizeof(scoreText)) {
-        printf("Error formatting score text\n");
+        ESP_LOGE(TAG, "Error formatting score text");
         lv_label_set_text(scoreLabel_, "Score: Error");
         return;
     }
     
     lv_label_set_text(scoreLabel_, scoreText);
-    printf("Score updated: %s\n", scoreText);
+    ESP_LOGI(TAG, "Score updated: %s", scoreText);
 }
 
 void TowerBloxx::swingAnimationCallback(void* obj, int32_t value) {

--- a/games/tower_bloxx/TowerBloxx.cpp
+++ b/games/tower_bloxx/TowerBloxx.cpp
@@ -10,7 +10,7 @@
 #include <algorithm>
 #include "esp_log.h"
 
-static const char *TAG = "MyComponent";
+static const char *TAG = "TowerBloxx";
 
 RegisterTowerBloxx::RegisterTowerBloxx() {
     GameRegistry::instance().registerGame("Tower Bloxx", []() {

--- a/hw_drivers/gpio_driver.c
+++ b/hw_drivers/gpio_driver.c
@@ -7,6 +7,9 @@
 #include "freertos/task.h"
 #include <stdint.h>
 #include <stdio.h>
+#include "esp_log.h"
+
+static const char *TAG = "MyComponent";
 
 typedef struct {
     int pin;
@@ -67,7 +70,7 @@ void init_gpio() {
 
     init_input_pins();
     
-    printf("GPIO initialized with debouncing\n");
+    ESP_LOGI(TAG, "GPIO initialized with debouncing");
 }
 
 int read_button() {
@@ -83,7 +86,7 @@ int read_button() {
                 btn->last_press_time = current_time;
                 btn->previous_state = btn->current_state;
                 
-                printf("%s pressed (debounced)\n", btn->name);
+                ESP_LOGI(TAG, "%s pressed (debounced)", btn->name);
                 return btn->lv_key;
             }
         } else if (btn->previous_state == 0 && btn->current_state == 1) {

--- a/hw_drivers/gpio_driver.c
+++ b/hw_drivers/gpio_driver.c
@@ -9,7 +9,7 @@
 #include <stdio.h>
 #include "esp_log.h"
 
-static const char *TAG = "MyComponent";
+static const char *TAG = "GPIO_DRIVER";
 
 typedef struct {
     int pin;

--- a/lvgl_app/lvgl_init.c
+++ b/lvgl_app/lvgl_init.c
@@ -9,7 +9,7 @@
 #include "display_driver.h"
 
 
-#define TAG "LVGL APPLICATION"
+static const char *TAG = "MyComponent";
 void (*handle_input_event)(uint32_t key) = NULL;
 
 static esp_lcd_panel_io_handle_t lcd_io_handle = NULL;
@@ -23,12 +23,12 @@ static void button_read(lv_indev_t * indev, lv_indev_data_t * data)
     if (key >= 0) {
         last_key = key;
         data->state = LV_INDEV_STATE_PRESSED;
-        printf("Button read: %d (pressed)\n", key);
+        ESP_LOGI(TAG, "Button read: %d (pressed)", key);
         
         if (handle_input_event) {
             handle_input_event((uint32_t)key);
         } else {
-            printf("ERROR: handle_input_event is NULL in button_read\n");
+            ESP_LOGE(TAG, "handle_input_event is NULL in button_read");
         }
     } else {
         data->state = LV_INDEV_STATE_RELEASED;

--- a/lvgl_app/lvgl_init.c
+++ b/lvgl_app/lvgl_init.c
@@ -9,7 +9,7 @@
 #include "display_driver.h"
 
 
-static const char *TAG = "MyComponent";
+static const char *TAG = "lvgl_init";
 void (*handle_input_event)(uint32_t key) = NULL;
 
 static esp_lcd_panel_io_handle_t lcd_io_handle = NULL;

--- a/main/app.cpp
+++ b/main/app.cpp
@@ -5,6 +5,9 @@
 #include "GamesConnector.hpp"
 #include "lvgl.h"
 #include <cstdio>
+#include "esp_log.h"
+
+static const char *TAG = "MyComponent";
 
 extern "C" void (*handle_input_event)(uint32_t key);
 
@@ -12,7 +15,7 @@ static bool initialized = false;
 
 void process_game_logic(void) {
     if (!initialized) {
-        printf("Initializing game logic\n");
+        ESP_LOGI(TAG, "Initializing game logic");
 
         ScreenManager::instance().init();
 
@@ -22,10 +25,10 @@ void process_game_logic(void) {
     if (ScreenManager::instance().state() == ScreenManager::State::GAME) {
         Game* currentGame = ScreenManager::instance().getCurrentGame();
         if (currentGame) {
-            printf("Calling game update()\n");
+            ESP_LOGI(TAG, "Calling game update()");
             currentGame->update();
         } else {
-            printf("No active game to update\n");
+            ESP_LOGI(TAG, "No active game to update");
         }
     }
 }

--- a/main/app.cpp
+++ b/main/app.cpp
@@ -7,7 +7,7 @@
 #include <cstdio>
 #include "esp_log.h"
 
-static const char *TAG = "MyComponent";
+static const char *TAG = "App";
 
 extern "C" void (*handle_input_event)(uint32_t key);
 

--- a/platform/InputRouter.cpp
+++ b/platform/InputRouter.cpp
@@ -2,6 +2,9 @@
 #include "lvgl.h"
 #include "app.h"
 #include <cstdio>
+#include "esp_log.h"
+
+static const char *TAG = "MyComponent";
 
 extern "C" void (*handle_input_event)(uint32_t key);
 
@@ -19,24 +22,24 @@ InputRouter::InputRouter() {
 
     // Set global handler
     handle_input_event = [](uint32_t k) {
-        printf("Key press detected in InputRouter: %lu\n", k);
+        ESP_LOGI(TAG, "Key press detected in InputRouter: %lu", k);
         InputRouter::instance()->dispatchKey(k);
     };
     
-    printf("InputRouter initialized\n");
+    ESP_LOGI(TAG, "InputRouter initialized");
 }
 
 void InputRouter::dispatchKey(uint32_t key) {
-    printf("InputRouter dispatching key: %lu\n", key);
+    ESP_LOGI(TAG, "InputRouter dispatching key: %lu", key);
     if (cb_) {
         cb_(key);
     } else {
-        printf("WARNING: No callback registered in InputRouter\n");
+        ESP_LOGW(TAG, "No callback registered in InputRouter");
     }
 }
 
 void InputRouter::setCallback(Callback cb) {
-    printf("InputRouter callback set\n");
+    ESP_LOGI(TAG, "InputRouter callback set");
     cb_ = std::move(cb);
 }
 

--- a/platform/InputRouter.cpp
+++ b/platform/InputRouter.cpp
@@ -4,7 +4,7 @@
 #include <cstdio>
 #include "esp_log.h"
 
-static const char *TAG = "MyComponent";
+static const char *TAG = "InputRouter";
 
 extern "C" void (*handle_input_event)(uint32_t key);
 

--- a/screens/ScreenManager.cpp
+++ b/screens/ScreenManager.cpp
@@ -1,5 +1,8 @@
 #include "ScreenManager.hpp"
 #include <cstdio>
+#include "esp_log.h"
+
+static const char *TAG = "MyComponent";
 
 ScreenManager* ScreenManager::instance_ = nullptr;
 
@@ -16,25 +19,25 @@ ScreenManager::ScreenManager()
         switchToGame(gameFactory);
     });
     
-    printf("ScreenManager constructed\n");
+    ESP_LOGI(TAG, "ScreenManager constructed");
 }
 
 void ScreenManager::init() {
     if (!initialized_) {
         InputRouter::instance()->setCallback([this](uint32_t key) {
-            printf("ScreenManager received key: %lu\n", key);
+            ESP_LOGI(TAG, "ScreenManager received key: %lu", key);
             handleInput(key);
         });
         
         initialized_ = true;
-        printf("ScreenManager initialized\n");
+        ESP_LOGI(TAG, "ScreenManager initialized");
     }
     
     switchToMenu();
 }
 
 void ScreenManager::switchToMenu() {
-    printf("Switching to Menu\n");
+    ESP_LOGI(TAG, "Switching to Menu");
     
     if (currentGame_) {
         Game* gameToDelete = currentGame_.release();
@@ -50,7 +53,7 @@ void ScreenManager::switchToMenu() {
 }
 
 void ScreenManager::switchToGame(const GameFactory& gameFactory) {
-    printf("Switching to Game: %s\n", gameFactory.name.c_str());
+    ESP_LOGI(TAG, "Switching to Game: %s", gameFactory.name.c_str());
     
     currentGame_ = gameFactory.create();
     
@@ -58,25 +61,25 @@ void ScreenManager::switchToGame(const GameFactory& gameFactory) {
         currentGame_->run();
         state_ = State::GAME;
     } else {
-        printf("Failed to create game\n");
+        ESP_LOGE(TAG, "Failed to create game");
         switchToMenu();
     }
 }
 
 void ScreenManager::handleInput(uint32_t key) {
-    printf("ScreenManager handling key: %lu, state: %d\n", key, (int)state_);
+    ESP_LOGI(TAG, "ScreenManager handling key: %lu, state: %d", key, (int)state_);
 
     if (state_ == State::GAME && (key == LV_KEY_ESC || key == LV_KEY_BACKSPACE)) {
-        printf("Exit from game requested by ScreenManager\n");
+        ESP_LOGI(TAG, "Exit from game requested by ScreenManager");
         switchToMenu();
         return;
     }
     
     if (state_ == State::MENU) {
-        printf("Passing key to MenuScreen: %lu\n", key);
+        ESP_LOGI(TAG, "Passing key to MenuScreen: %lu", key);
         menuScreen_.handleInput(key);
     } else if (state_ == State::GAME && currentGame_) {
-        printf("Passing key to Game: %lu\n", key);
+        ESP_LOGI(TAG, "Passing key to Game: %lu", key);
         currentGame_->handleKey(key);
     }
 }

--- a/screens/ScreenManager.cpp
+++ b/screens/ScreenManager.cpp
@@ -2,7 +2,7 @@
 #include <cstdio>
 #include "esp_log.h"
 
-static const char *TAG = "MyComponent";
+static const char *TAG = "ScreenManager";
 
 ScreenManager* ScreenManager::instance_ = nullptr;
 


### PR DESCRIPTION
## Summary
- migrate printf statements to ESP_LOG macros across project files
- add esp_log.h and uniform TAG definitions

## Testing
- `grep -R "\bprintf\s*(" --exclude-dir=build --exclude-dir=.git --exclude-dir=components -n`

------
https://chatgpt.com/codex/tasks/task_e_687a9ea6c414832a866f80a665ca46a7